### PR TITLE
Fix example SCC for deployment

### DIFF
--- a/sqlonopenshift/01_deploy/restrictedfsgroupscc.yaml
+++ b/sqlonopenshift/01_deploy/restrictedfsgroupscc.yaml
@@ -13,21 +13,10 @@ fsGroup:
   ranges: 
   - max: 20000
     min: 10000 
-groups:
-- system:authenticated
+groups: []
 kind: SecurityContextConstraints
 metadata:
-  annotations:
-    kubernetes.io/description: restricted denies access to all host features and requires
-      pods to be run with a UID, and SELinux context that are allocated to the namespace.  This
-      is the most restrictive SCC and it is used by default for authenticated users.
-    release.openshift.io/create-only: "true"
-  creationTimestamp: "2020-10-07T00:59:04Z"
-  generation: 1
   name: restrictedfsgroup
-  resourceVersion: "938"
-  selfLink: /apis/security.openshift.io/v1/securitycontextconstraints/restricted
-  uid: 9b80a629-a5c3-4507-bfb0-c480df9967ba
 priority: null
 readOnlyRootFilesystem: false
 requiredDropCapabilities:


### PR DESCRIPTION
Remove incorrect metadata from the original restricted SCC, and don't automatically add the system:authenticated group